### PR TITLE
move install items out of requirements textfile for portability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,8 @@ runs:
           python3 -m venv .env
           source .env/bin/activate
           python -m pip install -U pip
-          pip install -r requirements.txt
+          pip install openai
+          pip install requests
       - name: Review PR and make comment
         shell: bash
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-openai
-requests


### PR DESCRIPTION
So the end user does not have to host a requirements.txt file, and the list is so short, I'm moving the items out of requirements.txt and into the github actions file.